### PR TITLE
Enable CodeQL Analysis, make Dependabot run more often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 version: 2
+
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
+    interval: daily
+
+- package-ecosystem: github-actions
+  directory: /
   schedule:
-    interval: weekly
+    interval: daily

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+  schedule:
+    - cron: "36 10 * * 4"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
I'd like Dependabot to run more often to pull the new plugin release: https://github.com/terraform-linters/tflint-plugin-sdk/releases/tag/v0.12.0