### PR TITLE
Describe the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Then, enable it with:
 ```hcl
 plugin "camunda-saas" {
   enabled = true
+  version = "v1.1.0"
+  source  = "github.com/camunda-cloud/tflint-ruleset-camunda-saas"
 }
 ```
 
@@ -23,6 +25,32 @@ Open the [documentation](./docs/README.md) to get the list of rules.
 
 
 ## Development
+
+### Making a release
+
+1. Create a new Git tag, using the `vX.Y.Z` format:
+
+   ```
+   git tag --annotate --sign --amend "Release vX.Y.Z" vX.Y.Z
+   ```
+
+1. Push the new tag to GitHub:
+
+   ```
+   git push vX.Y.Z
+   ```
+
+1. GitHub Actions should take care of creating the artifacts and creating the GitHub Releases.
+1. Update the TFLint configuration file to use the new version:
+
+   ```hcl
+   plugin "camunda-saas" {
+     enabled = true
+     version = "vX.Y.Z"
+     source  = "github.com/camunda-cloud/tflint-ruleset-camunda-saas"
+   }
+   ```
+
 
 
 ### Building the plugin


### PR DESCRIPTION
I'm going to release 1.1.0 with https://github.com/camunda-cloud/tflint-ruleset-camunda-saas/pull/8 after that.